### PR TITLE
handle string dates in config

### DIFF
--- a/mmm/parser/csv.py
+++ b/mmm/parser/csv.py
@@ -78,8 +78,14 @@ def _parse_csv_shared(
         end_date_config = "end_period_label"
 
     if start_date_config in config["data_rows"] and end_date_config in config["data_rows"]:
-        start = config["data_rows"][start_date_config].isoformat()
-        end = config["data_rows"][end_date_config].isoformat()
+        # with yaml we may have a string or already a datetime object
+        # if a string we assume it's already isoformat
+        if isinstance(config["data_rows"][start_date_config], str):
+           start = config["data_rows"][start_date_config]
+           end = config["data_rows"][end_date_config]
+        else:
+            start = config["data_rows"][start_date_config].isoformat()
+            end = config["data_rows"][end_date_config].isoformat()
 
         if has_geo:
             # Compute a slice that includes all geos but only dates between start and end

--- a/test/auto/test_parser.py
+++ b/test/auto/test_parser.py
@@ -1,6 +1,7 @@
 import numpy as np
 import os
 import unittest
+from datetime import date
 
 from base_driver.config import load_config
 from mmm.parser.csv import parse_csv_generic
@@ -25,3 +26,36 @@ class CSVParserTest(unittest.TestCase):
         np.testing.assert_array_equal(data_dict["metrics"]["Impressions2"], [0.0, 1.0] * 5)
 
         np.testing.assert_array_equal(data_dict["metrics"]["Target"], range(10, 110, 10))
+
+    def test_parse_csv_generic_with_dates_as_strings(self):
+        config_filename = os.path.join(os.path.dirname(__file__), "..", "test.yaml")
+        input_filename = os.path.join(os.path.dirname(__file__), "..", "test.csv")
+
+        _, config = load_config(config_filename)
+
+        # check that the dates are already date objects
+        self.assertIsInstance(config["data_rows"]["start_date"], date)
+        self.assertIsInstance(config["data_rows"]["end_date"], date)
+
+        # now set the dates as strings, which would happen if the config
+        # had start_date: "2023-01-01" not start_date: 2023-01-01
+        # because yaml parsing handles the two differently
+        config["data_rows"]["start_date"] = "2023-01-01"
+
+        config["data_rows"]["end_date"] = "2023-01-10"
+
+        data_dict = parse_csv_generic(input_filename, config)
+
+        self.assertEqual(data_dict["granularity"], config["raw_data_granularity"])
+
+        np.testing.assert_array_equal(
+            data_dict["date_strs"], [f"2023-01-{n:02}" for n in range(1, 11)]
+        )
+
+        np.testing.assert_array_equal(data_dict["metrics"]["Spend1"], range(1, 11))
+
+        np.testing.assert_array_equal(data_dict["metrics"]["Impressions2"], [0.0, 1.0] * 5)
+
+        np.testing.assert_array_equal(data_dict["metrics"]["Target"], range(10, 110, 10))
+
+        self.assertEqual(data_dict["granularity"], config["raw_data_granularity"])


### PR DESCRIPTION
motivated by an exception:
```
'str' object has no attribute 'isoformat'
Traceback (most recent call last):
  File "/internal-mmm/driver/driver.py", line 240, in main
    input_data_raw = self.ingest_data(datafiles_root, customer, input_filename, config)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/internal-mmm/driver/driver.py", line 66, in ingest_data
    data_dict = parse_csv_generic(input_path, config)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/internal-mmm/mmm/mmm/parser/csv.py", line 145, in parse_csv_generic
    data_df = _parse_csv_shared(data_fname, config, geo_filter=geo_filter)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/internal-mmm/mmm/mmm/parser/csv.py", line 81, in _parse_csv_shared
    start = config["data_rows"][start_date_config].isoformat()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'isoformat'
```

which occurs when we provided dates a little differently

```yaml
data_rows:
  start_date: '2025-01-01'
```

versus the "expected"

```yaml
data_rows:
  start_date: 2025-01-01
```

sigh, yaml is a pain...