### PR TITLE
set default train/test split to 1 and handle missing `data_groupby`

### DIFF
--- a/mmm/data/data_to_fit.py
+++ b/mmm/data/data_to_fit.py
@@ -31,7 +31,8 @@ class DataToFit:
         has_geo = input_data.geo_names is not None
         data_size = input_data.media_data.shape[0]
 
-        split_ratio = config.get("train_test_ratio", 0.9)
+        # if unset, use all data for training and no test data
+        split_ratio = config.get("train_test_ratio", 1.0)
         split_point = math.ceil(data_size * split_ratio)
 
         if has_geo:

--- a/mmm/data/historical_predict.py
+++ b/mmm/data/historical_predict.py
@@ -388,11 +388,12 @@ def create_historical_predictions_daily_df(
     daily_media_contribution_pct_st = name_to_breakdown["daily_media_contribution_pct_st"]
 
     first_day = pd.to_datetime(data_to_fit.date_strs[0])
-    if config["data_groupby"] == "week":
+    groupby = config.get("data_groupby", None)
+    if groupby == "week":
         last_day = pd.to_datetime(data_to_fit.date_strs[-1]) + pd.Timedelta(days=6)
-    elif config["data_groupby"] == "two_weeks":
+    elif groupby == "two_weeks":
         last_day = pd.to_datetime(data_to_fit.date_strs[-1]) + pd.Timedelta(days=13)
-    elif config["data_groupby"] == "four_weeks":
+    elif groupby == "four_weeks":
         last_day = pd.to_datetime(data_to_fit.date_strs[-1]) + pd.Timedelta(days=27)
     else:
         last_day = pd.to_datetime(data_to_fit.date_strs[-1])

--- a/mmm/describe/describe.py
+++ b/mmm/describe/describe.py
@@ -1114,9 +1114,9 @@ def get_media_and_baseline_contribution_df(
         period_predictions_df = daily_predictions_df.resample(
             mode, label="left", closed="left"
         ).sum()
-        period_predictions_df["date"] = (
-            period_predictions_df.index
-        )  # Add date as column after resampling
+    period_predictions_df["date"] = (
+        period_predictions_df.index
+    )  # Add date as column after resampling
 
     channel_names = [m["display_name"] for m in config["media"]]
     # reverse the order of channel names to match lightweight mmm


### PR DESCRIPTION
* as part of internal testing we discovered that we always use train_test split of 1 and handling train/test splits are tricky (and fail later in pipeline anyways), so setting == 1.0 for now

* also handles case of some missing `data_groupby` configs