### PR TITLE
fixup requires-python specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,4 @@
 line-length = 100
 
 [project]
-requires-python = "3.11"
+requires-python = "==3.11"


### PR DESCRIPTION
whoops! supposed to use `==3.11` not just `3.11`; impacts some code formatting tools