### PR TITLE
Bump GitPython 3.1.42 -> 3.1.50 (P-4595)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # direct dependencies: utils for command line and config
 click==8.1.7
-GitPython==3.1.42
+GitPython==3.1.50
 msgpack==1.0.7
 msgpack-numpy==0.4.8
 PyYAML==6.0.1


### PR DESCRIPTION
## What
Bumps `GitPython` from `3.1.42` to `3.1.50` in `requirements.txt`.

## Why
Remediates high-severity GitHub Dependabot advisories for GitPython as part of Linear **P-4595** (Vanta vulnerability remediation). `3.1.50` is the first patched version covering all stacked advisories:

- GHSA-rpm5-65cw-6hj4
- GHSA-x2qx-6953-8485
- GHSA-7545-fcxq-7j24
- GHSA-v87r-6q3f-2j67
- GHSA-mv93-w799-cj2w

🤖 Generated with [Claude Code](https://claude.com/claude-code)