### PR TITLE
Support non-Sunday weekly grids in DataToFit index freq

### DIFF
--- a/mmm/data/data_to_fit.py
+++ b/mmm/data/data_to_fit.py
@@ -397,21 +397,34 @@ class DataToFit:
             observation_data_by_column_name[self.target_name] = target_data_scaled
 
         # TODO push conversion to datetime upstream so that it is common across all data sets
+        dates = pd.to_datetime(self.date_strs, dayfirst=False, yearfirst=False)
+
         if self.time_granularity == constants.GRANULARITY_WEEKLY:
-            freq = "W"
+            weeks_prefix = "W"
         elif self.time_granularity == constants.GRANULARITY_TWO_WEEKS:
-            freq = "2W"
+            weeks_prefix = "2W"
         elif self.time_granularity == constants.GRANULARITY_FOUR_WEEKS:
-            freq = "4W"
+            weeks_prefix = "4W"
         elif self.time_granularity == constants.GRANULARITY_DAILY:
-            freq = "D"
+            weeks_prefix = None
         else:
             assert False
+
+        if weeks_prefix is None:
+            freq = "D"
+        else:
+            # Weekly grids are anchored to the configured end date rather than
+            # fixed to Sundays, so observations can fall on any day of week.
+            # Derive the anchored pandas alias from the actual dates — a bare
+            # "W" (= "W-SUN") would raise on non-Sunday dates.
+            day_abbrs = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"]
+            anchor_day = day_abbrs[dates[0].weekday()] if len(dates) else "SUN"
+            freq = f"{weeks_prefix}-{anchor_day}"
 
         per_observation_df = pd.DataFrame(
             data=observation_data_by_column_name,
             index=pd.DatetimeIndex(
-                pd.to_datetime(self.date_strs, dayfirst=False, yearfirst=False),
+                dates,
                 freq=freq,
             ),
             dtype=np.float64,

--- a/mmm/data/input_data.py
+++ b/mmm/data/input_data.py
@@ -556,8 +556,11 @@ class InputData:
 
         The data will be grouped into groups of N*7 rows, starting with the first 7 rows, and
         discarding the last group of less than N*7 rows.  This means that the groups are aligned
-        to the day of week for the first row, not necessarily Sunday.  So the caller should ensure
-        that the first day of the dataset is a Sunday.
+        to the day of week for the first row.  Weekly grids are anchored to the configured end
+        date (see internal-mmm's utils.dates), so the caller should ensure the dataset spans a
+        whole number of periods — i.e. the first day is a whole number of periods before
+        (end_date + 1 day) — otherwise days are silently trimmed off the END of the data.  The
+        lightweight_mmm driver aligns data_rows.start_date accordingly before parsing.
 
         Args:
             time_granularity: granularity we should resample to

--- a/mmm/data/input_data.py
+++ b/mmm/data/input_data.py
@@ -556,11 +556,8 @@ class InputData:
 
         The data will be grouped into groups of N*7 rows, starting with the first 7 rows, and
         discarding the last group of less than N*7 rows.  This means that the groups are aligned
-        to the day of week for the first row.  Weekly grids are anchored to the configured end
-        date (see internal-mmm's utils.dates), so the caller should ensure the dataset spans a
-        whole number of periods — i.e. the first day is a whole number of periods before
-        (end_date + 1 day) — otherwise days are silently trimmed off the END of the data.  The
-        lightweight_mmm driver aligns data_rows.start_date accordingly before parsing.
+        to the day of week for the first row, not necessarily Sunday.  So the caller should ensure
+        that the first day of the dataset is a Sunday.
 
         Args:
             time_granularity: granularity we should resample to

--- a/mmm/parser/csv.py
+++ b/mmm/parser/csv.py
@@ -134,11 +134,17 @@ def parse_csv_generic(
     data_fname: str,
     config: dict,
     geo_filter: str = None,
+    data_df: pd.DataFrame = None,
 ):
     """
-    :param data_fname: full path to file for raw data
+    :param data_fname: full path to file for raw data (ignored when data_df is given)
     :param config: config dictionary (from yaml file)
     :param geo_filter: geo to filter the data on, or None to parse data for all geos
+    :param data_df: optional pre-parsed DataFrame in the shape returned by
+        csv_to_df_generic (indexed by date, or [geo, date] for geo data). Callers
+        pass this to feed data they have already transformed — e.g. downsampled
+        from daily to weekly with a shared, grid-anchored resample — in which case
+        config's raw_data_granularity must describe the frame's actual granularity.
 
     :return: dict with format {
             KEY_GRANULARITY: granularity,
@@ -148,7 +154,8 @@ def parse_csv_generic(
               for a geo model: { geo: { metric_name: [ metric values ], ... } }
         }
     """
-    data_df = _parse_csv_shared(data_fname, config, geo_filter=geo_filter)
+    if data_df is None:
+        data_df = _parse_csv_shared(data_fname, config, geo_filter=geo_filter)
 
     has_geo_data = config.get("geo_col", None) and not geo_filter
 


### PR DESCRIPTION
Support code for a daily→weekly downsampling re-anchor:
* we're moving weekly MMM data from pandas' default Sunday–Saturday weeks to a weekly grid **anchored to the configured end date**, so the most recent data always forms a complete week.
- `DataToFit.to_data_frame` hardcoded `freq="W"` (= `W-SUN`) on the per-observation index, which raises `ValueError` when reloading data where the weeks don't start on Sundays. It now derives the anchored alias (`W-TUE`, `2W-MON`, etc) from the actual dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)