### PR TITLE
Deps: bump msgpack 1.0.7 -> 1.2.1 (P-4934)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # direct dependencies: utils for command line and config
 click==8.1.7
 GitPython==3.1.50
-msgpack==1.0.7
+msgpack==1.2.1
 msgpack-numpy==0.4.8
 PyYAML==6.0.1
 


### PR DESCRIPTION
## What & why

Remediates high-severity **GHSA-6v7p-g79w-8964** tracked in [P-4934](https://linear.app/paramark/issue/P-4934) — a use-after-free in the msgpack `Unpacker` (reused after an error), a DoS risk on untrusted input. Fixed in msgpack **1.2.1**.

`requirements.txt`: `msgpack==1.0.7` → `msgpack==1.2.1`. `msgpack-numpy==0.4.8` requires `msgpack>=0.5.2`, so 1.2.1 is compatible.

## Out of scope

Sibling PRs for the same Vanta ticket: `paramark-inc/frontend` (npm alerts) and `paramark-inc/internal-mmm` (same msgpack CVE).

## Test plan

- [x] Verified `msgpack==1.2.1` + `msgpack-numpy==0.4.8` install together and pack/unpack roundtrip works
- [x] Reviewer: CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)